### PR TITLE
Add stdout to print output if any

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function rollupPluginCommit(options) {
       const target = targets.find(target => Boolean(options[cleanName(target)]));
       if (target) {
         const callback = (op) => (error, stdout, stderr) => (error)
-            ? console.error(stderr || `Failed to ${op} "${target}" \n ${error.cmd}.`)
+            ? console.error(stderr || `Failed to ${op} "${target}" \n ${error.cmd}. ${stdout ? ('\n' + stdout) : ''}`)
             : console.log(stdout || `Git ${op} successful for "${target}".`);
         exec(
           `git add ${target} ${


### PR DESCRIPTION
Can we also add `stdout` to the error console?
This will help users to know if there is any output for cases, for example, there is nothing to commit:

```
yarn build
yarn run v1.22.11
$ rollup -c rollup.config.js

src/index.js → build/index.js...
Failed to add/commit "../../config/studio/plugins/sidebar/bulkedit/index.js" 
 git add ../../config/studio/plugins/sidebar/bulkedit/index.js && git commit ../../config/studio/plugins/sidebar/bulkedit/index.js -m "Updates to index.js @ 2021.27.1 14:55". 
On branch master
nothing to commit, working tree clean
```